### PR TITLE
Close setup code block in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,4 @@ cd weigh-station
 python3 -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 uvicorn app.main:app --host 0.0.0.0 --port 8000
+```


### PR DESCRIPTION
## Summary
- close the setup instructions code fence in the README to render properly
- ensure the uvicorn launch command ends the block cleanly

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68c9dd1b94348332af9ea15187da68ce