### PR TITLE
Store operator on weigh events and fix commit save

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -30,6 +30,7 @@ class WeighEvent(Base):
     ts: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     variant_id: Mapped[int] = mapped_column(ForeignKey("variants.id"))
     serial: Mapped[str] = mapped_column(String(64))
+    operator: Mapped[Optional[str]] = mapped_column(String(64), nullable=True)
     gross_g: Mapped[float] = mapped_column(Float)
     net_g: Mapped[float] = mapped_column(Float)
     in_range: Mapped[bool] = mapped_column(Boolean)


### PR DESCRIPTION
## Summary
- add an operator field to weigh events so operator names are persisted
- update the commit endpoint to capture the operator, set in_range, and fix the drift filter invocation that caused save failures
- include the operator information in the CSV export for downstream reporting

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c9e2d27b988332af1112eacb88b33b