### PR TITLE
Use top navigation export link for CSV download

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -34,7 +34,7 @@
       <a href="/" class="active">Home</a>
       <a href="/settings">Settings</a>
       <a href="/stats">Stats</a>
-      <a href="/export">Export</a>
+      <a id="exportLink" href="/export.csv">Export</a>
     </nav>
   </header>
 
@@ -63,7 +63,6 @@
           <button id="saveBtn">Save</button>
           <button id="tareBtn">Tare</button>
           <button id="calBtn">Calibrate</button>
-          <button id="csvBtn">Download CSV</button>
         </div>
 
         <div class="kpis">
@@ -176,7 +175,13 @@ window.addEventListener('load', ()=>{
   $('saveBtn').addEventListener('click', doSave);
   $('tareBtn').addEventListener('click', doTare);
   $('calBtn'). addEventListener('click', doCal);
-  $('csvBtn'). addEventListener('click', exportCsv);
+  const exportLink = $('exportLink');
+  if(exportLink){
+    exportLink.addEventListener('click', ev => {
+      ev.preventDefault();
+      exportCsv();
+    });
+  }
   $('serial').focus();
 });
 </script>

--- a/app/static/settings.html
+++ b/app/static/settings.html
@@ -13,7 +13,7 @@
       <a href="/">Home</a>
       <a href="/settings" class="active">Settings</a>
       <a href="/stats">Stats</a>
-      <a href="/export">Export</a>
+      <a href="/export.csv">Export</a>
     </nav>
   </header>
 

--- a/app/static/stats.html
+++ b/app/static/stats.html
@@ -36,7 +36,7 @@
     <a href="/">Home</a>
     <a href="/settings">Settings</a>
     <strong style="flex:1">Statistics</strong>
-    <a href="/export">Export</a>
+    <a href="/export.csv">Export</a>
   </div>
 </header>
 


### PR DESCRIPTION
## Summary
- remove the redundant Download CSV button from the weigh view
- hook the top navigation Export link so it triggers the CSV download for the active variant
- point other navigation Export links directly at the CSV export endpoint for consistency

## Testing
- not run (static change)


------
https://chatgpt.com/codex/tasks/task_e_68c9e5dda2708332816e48eb12f0d909