### PR TITLE
Add production output reporting page

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI, WebSocket, WebSocketDisconnect, HTTPException, Quer
 from fastapi.responses import HTMLResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field
-from sqlalchemy import create_engine, select
+from sqlalchemy import create_engine, select, func, case
 from sqlalchemy.orm import sessionmaker
 from app.models import Base, Variant, Calibration, WeighEvent
 from app.hx711_reader import ScaleReader
@@ -69,6 +69,10 @@ def index():
 @app.get("/settings", response_class=HTMLResponse)
 def settings():
     return (STATIC_DIR / "settings.html").read_text(encoding="utf-8")
+
+@app.get("/production", response_class=HTMLResponse)
+def production_output_page():
+    return (STATIC_DIR / "production.html").read_text(encoding="utf-8")
 # --- Variant CRUD
 @app.get("/api/variants", response_model=List[VariantOut])
 def list_variants():
@@ -184,6 +188,109 @@ def stats(variant_id: Optional[int] = None):
         pass_count = q.filter(WeighEvent.in_range.is_(True)).count()
         fail_count = q.filter(WeighEvent.in_range.is_(False)).count()
         return {"pass": pass_count, "fail": fail_count, "total": pass_count + fail_count}
+
+@app.get("/api/production/output")
+def production_output(
+    interval: str = Query("day", pattern="^(day|hour)$"),
+    start: Optional[str] = Query(None, description="Start date (YYYY-MM-DD)"),
+    end: Optional[str] = Query(None, description="End date (YYYY-MM-DD)"),
+    variant_id: Optional[int] = Query(None, ge=1),
+):
+    interval = (interval or "day").lower()
+    if interval not in {"day", "hour"}:
+        raise HTTPException(400, "interval must be 'day' or 'hour'")
+
+    def parse_iso_date(value: Optional[str], label: str):
+        if value in (None, ""):
+            return None
+        try:
+            return datetime.strptime(value, "%Y-%m-%d").date()
+        except ValueError:
+            raise HTTPException(400, f"{label} must be YYYY-MM-DD")
+
+    start_date = parse_iso_date(start, "start")
+    end_date = parse_iso_date(end, "end")
+    today = datetime.utcnow().date()
+    if end_date is None:
+        end_date = today
+    if start_date is None:
+        start_date = end_date - timedelta(days=6)
+    if start_date > end_date:
+        raise HTTPException(400, "start must be on or before end")
+
+    start_dt = datetime.combine(start_date, time.min)
+    end_dt = datetime.combine(end_date + timedelta(days=1), time.min)
+
+    bucket_labels: List[str] = []
+    if interval == "day":
+        max_days = 180
+        day_count = (end_date - start_date).days + 1
+        if day_count > max_days:
+            raise HTTPException(400, f"Date range too large for daily view (max {max_days} days).")
+        current = start_date
+        while current <= end_date:
+            bucket_labels.append(current.isoformat())
+            current += timedelta(days=1)
+        bucket_format = "%Y-%m-%d"
+    else:
+        max_hours = 31 * 24  # ~1 month of hourly buckets
+        total_hours = int((end_dt - start_dt).total_seconds() // 3600)
+        if total_hours > max_hours:
+            raise HTTPException(400, f"Date range too large for hourly view (max {max_hours} hours).")
+        current_dt = start_dt
+        bucket_format = "%Y-%m-%d %H:00"
+        while current_dt < end_dt:
+            bucket_labels.append(current_dt.strftime(bucket_format))
+            current_dt += timedelta(hours=1)
+
+    bucket_col = func.strftime(bucket_format, WeighEvent.ts)
+    pass_sum = func.sum(case((WeighEvent.in_range.is_(True), 1), else_=0))
+    fail_sum = func.sum(case((WeighEvent.in_range.is_(False), 1), else_=0))
+
+    with Session() as s:
+        variant_meta = None
+        if variant_id is not None:
+            variant = s.get(Variant, int(variant_id))
+            if not variant:
+                raise HTTPException(404, "Variant not found")
+            variant_meta = {"id": variant.id, "name": variant.name}
+
+        q = s.query(
+            bucket_col.label("bucket"),
+            pass_sum.label("pass_count"),
+            fail_sum.label("fail_count"),
+        ).filter(WeighEvent.ts >= start_dt, WeighEvent.ts < end_dt)
+
+        if variant_id is not None:
+            q = q.filter(WeighEvent.variant_id == variant_id)
+
+        rows = q.group_by(bucket_col).order_by(bucket_col).all()
+
+    bucket_map = {row.bucket: row for row in rows}
+    data = []
+    total_pass = 0
+    total_fail = 0
+    for label in bucket_labels:
+        row = bucket_map.get(label)
+        p = int(row.pass_count) if row and row.pass_count is not None else 0
+        f = int(row.fail_count) if row and row.fail_count is not None else 0
+        data.append({"label": label, "pass": p, "fail": f})
+        total_pass += p
+        total_fail += f
+
+    return {
+        "interval": interval,
+        "start": start_date.isoformat(),
+        "end": end_date.isoformat(),
+        "bucket_count": len(bucket_labels),
+        "variant": variant_meta,
+        "buckets": data,
+        "totals": {
+            "pass": total_pass,
+            "fail": total_fail,
+            "total": total_pass + total_fail,
+        },
+    }
 # --- CSV export
 @app.get("/export.csv")
 def export_csv(frm: Optional[str] = None, to: Optional[str] = None, variant: Optional[int] = None):
@@ -304,7 +411,7 @@ def stats_summary(variant_id: int, bins: int = 20, frm: Optional[str] = None, to
         }
 # ---------- Distribution + Cp/Cpk ----------
 from math import sqrt, floor, ceil
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, time
 def _parse_day(d: str) -> datetime:
     return datetime.strptime(d, "%Y-%m-%d")
 @app.get("/api/stats/distribution")

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -33,6 +33,7 @@
     <nav class="nav">
       <a href="/" class="active">Home</a>
       <a href="/settings">Settings</a>
+      <a href="/production">Production</a>
       <a href="/stats">Stats</a>
       <a href="/export">Export</a>
     </nav>

--- a/app/static/production.html
+++ b/app/static/production.html
@@ -1,0 +1,102 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Production Output • Weigh Station</title>
+  <link rel="stylesheet" href="/static/styles.css?v=app-theme-1">
+  <style>
+    .filters { display:flex; flex-wrap:wrap; gap:14px; align-items:flex-end; }
+    .filters .field { display:flex; flex-direction:column; gap:6px; min-width:150px; }
+    .filters .field label { font-size:0.72rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--app-fg-muted); }
+    .metrics { display:grid; grid-template-columns:repeat(auto-fit,minmax(160px,1fr)); gap:14px; margin-bottom:18px; }
+    .metric { background:rgba(148,163,184,0.08); border-radius:14px; padding:14px 16px; display:flex; flex-direction:column; gap:6px; }
+    .metric .metric-label { font-size:0.8rem; text-transform:uppercase; letter-spacing:0.08em; color:var(--app-fg-muted); }
+    .metric .metric-value { font-weight:700; font-size:clamp(1.6rem,3vw,2.2rem); }
+    .chart-wrap { position:relative; width:100%; height:clamp(320px,60vh,540px); }
+    #outputChart { width:100%; height:100%; display:block; background:rgba(15,19,30,0.86); border:1px solid rgba(148,163,184,0.22); border-radius:18px; }
+    #emptyState { position:absolute; inset:0; display:flex; align-items:center; justify-content:center; text-align:center; color:var(--app-fg-muted); font-size:1rem; padding:0 18px; pointer-events:none; background:transparent; }
+    .legend { margin-top:14px; display:flex; gap:16px; flex-wrap:wrap; color:var(--app-fg-muted); font-size:0.9rem; }
+    .legend span { display:inline-flex; align-items:center; gap:8px; }
+    .legend i { width:14px; height:14px; border-radius:4px; display:inline-block; }
+    #status { margin-top:14px; min-height:1.4em; color:var(--app-fg-muted); }
+    @media (max-width: 720px) {
+      .filters { flex-direction:column; align-items:stretch; }
+      .filters button { width:100%; }
+    }
+  </style>
+</head>
+<body class="app dark">
+  <header class="card topbar">
+    <div class="brand">Weigh Station</div>
+    <nav class="nav">
+      <a href="/">Home</a>
+      <a href="/settings">Settings</a>
+      <a href="/production" class="active">Production</a>
+      <a href="/stats">Stats</a>
+      <a href="/export">Export</a>
+    </nav>
+  </header>
+
+  <main class="page">
+    <section class="card">
+      <div class="row between" style="align-items:flex-start;">
+        <div>
+          <h1 style="margin-bottom:6px;">Production Output</h1>
+          <p class="muted" style="max-width:520px;">Review pass and fail counts for each product version across the selected date range. Toggle between hourly and daily buckets to zoom in on throughput.</p>
+        </div>
+        <div class="filters">
+          <div class="field">
+            <label for="variant">Version</label>
+            <select id="variant"></select>
+          </div>
+          <div class="field">
+            <label for="interval">Group By</label>
+            <select id="interval">
+              <option value="day">Day</option>
+              <option value="hour">Hour</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="start">From</label>
+            <input type="date" id="start">
+          </div>
+          <div class="field">
+            <label for="end">To</label>
+            <input type="date" id="end">
+          </div>
+          <button id="refresh" class="secondary">Refresh</button>
+        </div>
+      </div>
+    </section>
+
+    <section class="card">
+      <div class="metrics">
+        <div class="metric">
+          <div class="metric-label">Total</div>
+          <div id="totalCount" class="metric-value">0</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Passed</div>
+          <div id="passCount" class="metric-value">0</div>
+        </div>
+        <div class="metric">
+          <div class="metric-label">Failed</div>
+          <div id="failCount" class="metric-value">0</div>
+        </div>
+      </div>
+      <div class="chart-wrap">
+        <canvas id="outputChart"></canvas>
+        <div id="emptyState" hidden>No production results for the selected filters.</div>
+      </div>
+      <div class="legend">
+        <span><i style="background:#22c55e;"></i>Passed</span>
+        <span><i style="background:#ef4444;"></i>Failed</span>
+      </div>
+      <div id="status"></div>
+    </section>
+  </main>
+
+  <script src="/static/production.js"></script>
+</body>
+</html>

--- a/app/static/production.js
+++ b/app/static/production.js
@@ -1,0 +1,271 @@
+const variantSelect = document.getElementById('variant');
+const intervalSelect = document.getElementById('interval');
+const startInput = document.getElementById('start');
+const endInput = document.getElementById('end');
+const refreshBtn = document.getElementById('refresh');
+const passEl = document.getElementById('passCount');
+const failEl = document.getElementById('failCount');
+const totalEl = document.getElementById('totalCount');
+const statusEl = document.getElementById('status');
+const canvas = document.getElementById('outputChart');
+const emptyState = document.getElementById('emptyState');
+const ctx = canvas.getContext('2d');
+
+let cachedChart = { labels: [], pass: [], fail: [], interval: 'day' };
+
+function setStatus(message, ok = true) {
+  statusEl.textContent = message || '';
+  statusEl.style.color = ok ? 'var(--app-fg-muted)' : '#f87171';
+}
+
+function setLoading(loading) {
+  refreshBtn.disabled = loading;
+  refreshBtn.textContent = loading ? 'Loading…' : 'Refresh';
+}
+
+function formatNum(value) {
+  const num = Number(value) || 0;
+  return num.toLocaleString();
+}
+
+async function loadVariants() {
+  const current = variantSelect.value || 'all';
+  try {
+    const res = await fetch('/api/variants', { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to load variants');
+    const variants = await res.json();
+    const options = ['<option value="all">All Versions</option>'];
+    for (const v of variants) {
+      options.push(`<option value="${v.id}">${v.name}</option>`);
+    }
+    variantSelect.innerHTML = options.join('');
+    if (variants.some(v => String(v.id) === current)) {
+      variantSelect.value = current;
+    } else {
+      variantSelect.value = 'all';
+    }
+  } catch (err) {
+    console.error(err);
+    variantSelect.innerHTML = '<option value="all">All Versions</option>';
+    variantSelect.value = 'all';
+    setStatus('Failed to load versions.', false);
+  }
+}
+
+function setDefaultRange() {
+  const now = new Date();
+  const end = now.toISOString().slice(0, 10);
+  const startDate = new Date(now.getTime() - 6 * 86400000);
+  const start = startDate.toISOString().slice(0, 10);
+  startInput.value = start;
+  endInput.value = end;
+}
+
+function buildQuery() {
+  const params = new URLSearchParams();
+  params.set('interval', intervalSelect.value);
+  if (startInput.value) params.set('start', startInput.value);
+  if (endInput.value) params.set('end', endInput.value);
+  if (variantSelect.value && variantSelect.value !== 'all') {
+    params.set('variant_id', variantSelect.value);
+  }
+  return params.toString();
+}
+
+function drawChart(labels, passData, failData, interval, cache = true) {
+  const width = canvas.clientWidth || 960;
+  const height = canvas.clientHeight || 420;
+  canvas.width = width;
+  canvas.height = height;
+  ctx.clearRect(0, 0, width, height);
+
+  if (!labels.length) {
+    if (cache) {
+      cachedChart = { labels: [], pass: [], fail: [], interval };
+    }
+    return;
+  }
+
+  const margin = {
+    left: 64,
+    right: 28,
+    top: 24,
+    bottom: interval === 'hour' ? 96 : 70,
+  };
+  const chartWidth = Math.max(1, width - margin.left - margin.right);
+  const chartHeight = Math.max(1, height - margin.top - margin.bottom);
+  const baseY = height - margin.bottom;
+  const topY = margin.top;
+
+  // axes
+  ctx.strokeStyle = 'rgba(148,163,184,0.22)';
+  ctx.lineWidth = 1;
+  ctx.beginPath();
+  ctx.moveTo(margin.left, baseY);
+  ctx.lineTo(width - margin.right, baseY);
+  ctx.moveTo(margin.left, baseY);
+  ctx.lineTo(margin.left, topY);
+  ctx.stroke();
+
+  const totals = labels.map((_, i) => (Number(passData[i]) || 0) + (Number(failData[i]) || 0));
+  const maxTotal = totals.length ? Math.max(...totals, 1) : 1;
+  const yTicks = 5;
+  ctx.font = '12px "Inter", system-ui, sans-serif';
+  ctx.textBaseline = 'middle';
+  for (let i = 0; i <= yTicks; i++) {
+    const value = (maxTotal / yTicks) * i;
+    const y = baseY - (value / maxTotal) * chartHeight;
+    ctx.strokeStyle = 'rgba(148,163,184,0.12)';
+    ctx.beginPath();
+    ctx.moveTo(margin.left, y);
+    ctx.lineTo(width - margin.right, y);
+    ctx.stroke();
+    ctx.fillStyle = '#64748b';
+    ctx.textAlign = 'right';
+    ctx.fillText(Math.round(value).toString(), margin.left - 8, y);
+  }
+
+  const slot = labels.length ? chartWidth / labels.length : chartWidth;
+  const gap = Math.min(8, slot * 0.25);
+  const barWidth = Math.max(2, Math.min(64, slot - gap));
+  const offset = (slot - barWidth) / 2;
+  const rotateLabels = interval === 'hour' || labels.length > 10;
+
+  for (let i = 0; i < labels.length; i++) {
+    const passVal = Number(passData[i]) || 0;
+    const failVal = Number(failData[i]) || 0;
+    const x = margin.left + slot * i + offset;
+    const scale = maxTotal ? chartHeight / maxTotal : 0;
+    const minVisible = chartHeight > 0 ? Math.min(2, chartHeight) : 0;
+    let passHeight = passVal * scale;
+    let failHeight = failVal * scale;
+    if (passVal > 0 && passHeight < minVisible) passHeight = minVisible;
+    if (failVal > 0 && failHeight < minVisible) failHeight = minVisible;
+    let combined = passHeight + failHeight;
+    if (combined > chartHeight) {
+      const ratio = chartHeight / combined;
+      passHeight *= ratio;
+      failHeight *= ratio;
+      combined = chartHeight;
+    }
+    const passY = baseY - passHeight;
+    const failY = passY - failHeight;
+
+    ctx.fillStyle = 'rgba(34,197,94,0.85)';
+    if (passHeight > 0) {
+      ctx.fillRect(x, passY, barWidth, passHeight);
+    }
+
+    ctx.fillStyle = 'rgba(239,68,68,0.85)';
+    if (failHeight > 0) {
+      ctx.fillRect(x, failY, barWidth, failHeight);
+    }
+
+    ctx.save();
+    const centerX = x + barWidth / 2;
+    ctx.fillStyle = '#94a3b8';
+    if (rotateLabels) {
+      ctx.translate(centerX, height - margin.bottom + 16);
+      ctx.rotate(-Math.PI / 4);
+      ctx.textAlign = 'right';
+      ctx.textBaseline = 'middle';
+      ctx.fillText(labels[i], 0, 0);
+    } else {
+      ctx.textAlign = 'center';
+      ctx.textBaseline = 'top';
+      ctx.fillText(labels[i], centerX, height - margin.bottom + 8);
+    }
+    ctx.restore();
+  }
+
+  if (cache) {
+    cachedChart = {
+      labels: labels.slice(),
+      pass: passData.slice(),
+      fail: failData.slice(),
+      interval,
+    };
+  }
+}
+
+async function refresh() {
+  if (startInput.value && endInput.value && startInput.value > endInput.value) {
+    setStatus('From date must be on or before the To date.', false);
+    return;
+  }
+
+  setLoading(true);
+  setStatus('Loading…');
+
+  try {
+    const query = buildQuery();
+    const res = await fetch(`/api/production/output?${query}`, { cache: 'no-store' });
+    if (!res.ok) {
+      let msg = 'Failed to load production output.';
+      try {
+        const err = await res.json();
+        if (err && err.detail) msg = err.detail;
+      } catch {}
+      throw new Error(msg);
+    }
+
+    const payload = await res.json();
+    const buckets = Array.isArray(payload.buckets) ? payload.buckets : [];
+    const labels = buckets.map(b => b.label);
+    const passData = buckets.map(b => b.pass ?? 0);
+    const failData = buckets.map(b => b.fail ?? 0);
+
+    drawChart(labels, passData, failData, payload.interval || intervalSelect.value);
+
+    const totals = payload.totals || {};
+    const passTotal = totals.pass ?? 0;
+    const failTotal = totals.fail ?? 0;
+    const total = totals.total ?? passTotal + failTotal;
+    passEl.textContent = formatNum(passTotal);
+    failEl.textContent = formatNum(failTotal);
+    totalEl.textContent = formatNum(total);
+
+    const hasValues = buckets.some(b => (Number(b.pass) || 0) + (Number(b.fail) || 0));
+    emptyState.hidden = hasValues;
+    if (!hasValues) {
+      emptyState.textContent = 'No production results for the selected filters.';
+    }
+
+    const variantName = payload.variant?.name;
+    const intervalLabel = (payload.interval === 'hour') ? 'hour' : 'day';
+    const plural = labels.length === 1 ? '' : 's';
+    const rangeText = `${payload.start ?? startInput.value || '—'} → ${payload.end ?? endInput.value || '—'}`;
+    const variantText = variantName ? ` • ${variantName}` : '';
+    setStatus(`Showing ${labels.length} ${intervalLabel}${plural} (${rangeText})${variantText}.`);
+  } catch (err) {
+    console.error(err);
+    drawChart([], [], [], intervalSelect.value);
+    cachedChart = { labels: [], pass: [], fail: [], interval: intervalSelect.value };
+    emptyState.hidden = false;
+    emptyState.textContent = err.message || 'No production results for the selected filters.';
+    passEl.textContent = '0';
+    failEl.textContent = '0';
+    totalEl.textContent = '0';
+    setStatus(err.message || 'Failed to load production output.', false);
+  } finally {
+    setLoading(false);
+  }
+}
+
+function handleResize() {
+  if (!cachedChart.labels.length) return;
+  drawChart(cachedChart.labels, cachedChart.pass, cachedChart.fail, cachedChart.interval, false);
+}
+
+refreshBtn.addEventListener('click', () => refresh());
+variantSelect.addEventListener('change', () => refresh());
+intervalSelect.addEventListener('change', () => refresh());
+startInput.addEventListener('change', () => refresh());
+endInput.addEventListener('change', () => refresh());
+window.addEventListener('resize', handleResize);
+
+(async function init() {
+  setDefaultRange();
+  await loadVariants();
+  await refresh();
+})();

--- a/app/static/settings.html
+++ b/app/static/settings.html
@@ -12,6 +12,7 @@
     <nav class="nav">
       <a href="/">Home</a>
       <a href="/settings" class="active">Settings</a>
+      <a href="/production">Production</a>
       <a href="/stats">Stats</a>
       <a href="/export">Export</a>
     </nav>

--- a/app/static/stats.html
+++ b/app/static/stats.html
@@ -35,6 +35,7 @@
   <div class="nav">
     <a href="/">Home</a>
     <a href="/settings">Settings</a>
+    <a href="/production">Production</a>
     <strong style="flex:1">Statistics</strong>
     <a href="/export">Export</a>
   </div>


### PR DESCRIPTION
## Summary
- add a new `/production` page that visualizes pass/fail throughput with date range, interval, and version filters
- expose `/api/production/output` to aggregate weigh events by day or hour for stacked charting
- update site navigation to link to the new production view

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9e5545a4c8332b45238217d8e5ebc