### PR TITLE
Move calibration controls to settings page

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -62,10 +62,9 @@
 
         <div class="actions">
           <button id="saveBtn">Save</button>
-          <a class="btn secondary" href="/settings">Settings &amp; Calibration</a>
         </div>
 
-        <p class="muted" style="margin-top:8px">Tare and calibration controls are now available on the Settings page.</p>
+        <p class="muted" style="margin-top:8px">Use the Settings page in the top navigation for tare and calibration controls.</p>
 
         <div class="kpis">
           <div class="card" style="padding:10px"><div style="opacity:.7">Pass</div><div id="passCount" class="num">0</div></div>

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -62,9 +62,10 @@
 
         <div class="actions">
           <button id="saveBtn">Save</button>
-          <button id="tareBtn">Tare</button>
-          <button id="calBtn">Calibrate</button>
+          <a class="btn secondary" href="/settings">Settings &amp; Calibration</a>
         </div>
+
+        <p class="muted" style="margin-top:8px">Tare and calibration controls are now available on the Settings page.</p>
 
         <div class="kpis">
           <div class="card" style="padding:10px"><div style="opacity:.7">Pass</div><div id="passCount" class="num">0</div></div>
@@ -140,15 +141,6 @@ async function refreshStats(){
   }catch{}
 }
 
-async function doTare(){ try{ await fetch('/api/tare',{method:'POST'}); setMsg('Tare applied'); } catch{ setMsg('Tare failed', false);} }
-async function doCal(){
-  try{
-    const v = prompt('Place known weight, enter grams (e.g. 200.0):'); if(!v) return;
-    const g = parseFloat(v); if(!isFinite(g) || g <= 0){ setMsg('Invalid reference weight', false); return; }
-    const r = await fetch(`/api/calibrate?ref_g=${encodeURIComponent(g)}`, {method:'POST'});
-    if(!r.ok) throw new Error(); setMsg('Calibration saved');
-  }catch{ setMsg('Calibration failed', false); }
-}
 function exportCsv(){
   if(!currentVariant){ setMsg('Choose variant', false); return; }
   const a=document.createElement('a');
@@ -174,8 +166,6 @@ window.addEventListener('load', ()=>{
   loadVariants();
   setInterval(refreshStats, 3000);
   $('saveBtn').addEventListener('click', doSave);
-  $('tareBtn').addEventListener('click', doTare);
-  $('calBtn'). addEventListener('click', doCal);
   const exportLink = $('exportLink');
   if(exportLink){
     exportLink.addEventListener('click', ev => {


### PR DESCRIPTION
## Summary
- remove tare and calibrate buttons from the home page controls
- add a settings link and explanatory note so users know where calibration now lives
- delete unused javascript handlers tied to the removed buttons

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68c9edbb5c1c83328a3622764a528544