### PR TITLE
Add configurable export page

### DIFF
--- a/app/static/export.html
+++ b/app/static/export.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8"/>
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Export Data • Weigh Station</title>
+  <link rel="stylesheet" href="/static/styles.css?v=app-theme-1">
+  <style>
+    .export-layout { display:flex; flex-direction:column; gap:18px; }
+    .export-form { display:grid; gap:16px; max-width:520px; }
+    .export-form .field { display:flex; flex-direction:column; gap:6px; }
+    .export-form label { font-size:0.72rem; letter-spacing:0.08em; text-transform:uppercase; color:var(--app-fg-muted); }
+    .export-actions { display:flex; gap:12px; flex-wrap:wrap; }
+    .export-actions button { min-width:160px; }
+    #status { min-height:1.4em; color:var(--app-fg-muted); }
+  </style>
+</head>
+<body class="app dark">
+  <header class="card topbar">
+    <div class="brand">Weigh Station</div>
+    <nav class="nav">
+      <a href="/">Home</a>
+      <a href="/settings">Settings</a>
+      <a href="/production">Production</a>
+      <a href="/stats">Stats</a>
+      <a href="/export" class="active">Export</a>
+    </nav>
+  </header>
+
+  <main class="page">
+    <section class="card">
+      <div class="export-layout">
+        <div>
+          <h1 style="margin-bottom:6px;">Export weigh data</h1>
+          <p class="muted" style="margin:0; max-width:560px;">Choose the filters that match the report you need. Leave a field blank to include all results. When you click Export, a CSV file will be prepared using the selected criteria.</p>
+        </div>
+        <form id="exportForm" class="export-form">
+          <div class="field">
+            <label for="variant">Variant</label>
+            <select id="variant" name="variant">
+              <option value="">All variants</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="operator">Operator</label>
+            <select id="operator" name="operator">
+              <option value="">All operators</option>
+            </select>
+          </div>
+          <div class="field">
+            <label for="from">From date</label>
+            <input type="date" id="from" name="from">
+          </div>
+          <div class="field">
+            <label for="to">To date</label>
+            <input type="date" id="to" name="to">
+          </div>
+          <div class="export-actions">
+            <button type="submit" id="downloadBtn">Export CSV</button>
+            <button type="button" id="resetBtn" class="secondary">Reset filters</button>
+          </div>
+          <div id="status" class="muted"></div>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <script src="/static/export.js"></script>
+</body>
+</html>

--- a/app/static/export.js
+++ b/app/static/export.js
@@ -1,0 +1,101 @@
+const form = document.getElementById('exportForm');
+const variantSelect = document.getElementById('variant');
+const operatorSelect = document.getElementById('operator');
+const fromInput = document.getElementById('from');
+const toInput = document.getElementById('to');
+const statusEl = document.getElementById('status');
+const resetBtn = document.getElementById('resetBtn');
+
+function setStatus(message, isError = false) {
+  if (!statusEl) return;
+  statusEl.textContent = message || '';
+  statusEl.style.color = isError ? '#f87171' : 'var(--app-fg-muted)';
+}
+
+function appendOption(select, value, label) {
+  const option = document.createElement('option');
+  option.value = value;
+  option.textContent = label;
+  select.appendChild(option);
+}
+
+async function loadVariants() {
+  if (!variantSelect) return;
+  try {
+    const res = await fetch('/api/variants', { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to load variants');
+    const variants = await res.json();
+    variantSelect.innerHTML = '';
+    appendOption(variantSelect, '', 'All variants');
+    for (const v of variants) {
+      const name = v.name || `Variant ${v.id}`;
+      const range = `${v.min_g} – ${v.max_g} ${v.unit || 'g'}`;
+      appendOption(variantSelect, String(v.id), `${name} [${range}]`);
+    }
+  } catch (err) {
+    console.error(err);
+    setStatus('Unable to load variants.', true);
+  }
+}
+
+async function loadOperators() {
+  if (!operatorSelect) return;
+  try {
+    const res = await fetch('/api/operators', { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to load operators');
+    const operators = await res.json();
+    operatorSelect.innerHTML = '';
+    appendOption(operatorSelect, '', 'All operators');
+    for (const name of operators) {
+      appendOption(operatorSelect, name, name);
+    }
+  } catch (err) {
+    console.error(err);
+    setStatus('Unable to load operators.', true);
+  }
+}
+
+function buildUrl() {
+  const params = new URLSearchParams();
+  const variant = variantSelect?.value;
+  if (variant) params.set('variant', variant);
+
+  const operator = operatorSelect?.value;
+  if (operator) params.set('operator', operator);
+
+  const from = fromInput?.value;
+  if (from) params.set('from', from);
+
+  const to = toInput?.value;
+  if (to) params.set('to', to);
+
+  const qs = params.toString();
+  return '/export.csv' + (qs ? `?${qs}` : '');
+}
+
+form?.addEventListener('submit', (event) => {
+  event.preventDefault();
+  const url = buildUrl();
+  setStatus('Preparing download…');
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  anchor.download = '';
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  setTimeout(() => setStatus(''), 2000);
+});
+
+resetBtn?.addEventListener('click', () => {
+  if (variantSelect) variantSelect.value = '';
+  if (operatorSelect) operatorSelect.value = '';
+  if (fromInput) fromInput.value = '';
+  if (toInput) toInput.value = '';
+  setStatus('Filters reset.');
+  setTimeout(() => setStatus(''), 2000);
+});
+
+window.addEventListener('load', () => {
+  loadVariants();
+  loadOperators();
+});

--- a/app/static/index.html
+++ b/app/static/index.html
@@ -35,7 +35,7 @@
       <a href="/settings">Settings</a>
       <a href="/production">Production</a>
       <a href="/stats">Stats</a>
-      <a id="exportLink" href="/export.csv">Export</a>
+      <a href="/export">Export</a>
     </nav>
   </header>
 
@@ -140,12 +140,6 @@ async function refreshStats(){
   }catch{}
 }
 
-function exportCsv(){
-  if(!currentVariant){ setMsg('Choose variant', false); return; }
-  const a=document.createElement('a');
-  a.href=`/export.csv?variant=${encodeURIComponent(currentVariant.id)}`;
-  a.download=''; document.body.appendChild(a); a.click(); a.remove();
-}
 async function doSave(){
   try{
     if(!currentVariant){ setMsg('Choose variant first', false); return; }
@@ -165,13 +159,6 @@ window.addEventListener('load', ()=>{
   loadVariants();
   setInterval(refreshStats, 3000);
   $('saveBtn').addEventListener('click', doSave);
-  const exportLink = $('exportLink');
-  if(exportLink){
-    exportLink.addEventListener('click', ev => {
-      ev.preventDefault();
-      exportCsv();
-    });
-  }
   $('serial').focus();
 });
 </script>

--- a/app/static/settings.html
+++ b/app/static/settings.html
@@ -14,7 +14,7 @@
       <a href="/settings" class="active">Settings</a>
       <a href="/production">Production</a>
       <a href="/stats">Stats</a>
-      <a href="/export.csv">Export</a>
+      <a href="/export">Export</a>
     </nav>
   </header>
 

--- a/app/static/stats.html
+++ b/app/static/stats.html
@@ -88,7 +88,7 @@
       <a href="/settings">Settings</a>
       <a href="/production">Production</a>
       <a href="/stats" class="active">Stats</a>
-      <a href="/export.csv">Export</a>
+      <a href="/export">Export</a>
     </nav>
   </header>
 


### PR DESCRIPTION
## Summary
- add a dedicated export page with controls for variant, operator, and date range filtering before downloading
- expose an operator listing API and extend the CSV export endpoint to honour operator and date filters
- update navigation links to send users to the new export workflow

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68cab51d99f48332a0894bc5d0fc80b5