### PR TITLE
Remove tare instruction text from home page

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -64,8 +64,6 @@
           <button id="saveBtn">Save</button>
         </div>
 
-        <p class="muted" style="margin-top:8px">Use the Settings page in the top navigation for tare and calibration controls.</p>
-
         <div class="kpis">
           <div class="card" style="padding:10px"><div style="opacity:.7">Pass</div><div id="passCount" class="num">0</div></div>
           <div class="card" style="padding:10px"><div style="opacity:.7">Fail</div><div id="failCount" class="num">0</div></div>


### PR DESCRIPTION
## Summary
- remove the home page note directing users to the Settings page for tare/calibration controls

## Testing
- pytest *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68caf1fc7e0483329b0fedfc71fc9dd9