### PR TITLE
Add stacked production output chart and relocate home status message

### DIFF
--- a/app/static/index.html
+++ b/app/static/index.html
@@ -24,7 +24,7 @@
     .actions{display:flex;gap:10px;flex-wrap:wrap;margin-top:12px}
     .kpis{display:grid;grid-template-columns:repeat(3,minmax(120px,1fr));gap:12px;margin-top:12px}
     .kpis .num{font-weight:700;font-size:clamp(20px,3.5vw,32px);text-align:center}
-    .footer-msg{min-height:1.4em;margin-top:8px}
+    .status-msg{min-height:2.4em;margin-bottom:18px;font-size:2rem;line-height:1.2;font-weight:600;text-align:center;color:#e2e8f0}
   </style>
 </head>
 <body class="app dark">
@@ -48,6 +48,7 @@
     <div class="layout">
       <!-- Left: live reading -->
       <section class="card reading-card" id="readingCard">
+        <div id="msg" class="status-msg"></div>
         <div id="reading" class="reading">0.0 g</div>
         <div id="readingSub" class="reading-sub">Waiting for scale…</div>
       </section>
@@ -90,8 +91,6 @@
           <div class="card" style="padding:10px"><div style="opacity:.7">Fail</div><div id="failCount" class="num">0</div></div>
           <div class="card" style="padding:10px"><div style="opacity:.7">Total</div><div id="totalCount" class="num">0</div></div>
         </div>
-
-        <div id="msg" class="footer-msg"></div>
       </section>
     </div>
   </main>

--- a/app/static/production.html
+++ b/app/static/production.html
@@ -18,14 +18,23 @@
     .table-scroll { overflow-x:auto; margin-top:12px; border-radius:12px; border:1px solid rgba(148,163,184,0.18); }
     .table-scroll table { min-width:720px; }
     #status { margin-top:14px; min-height:1.4em; color:var(--app-fg-muted); }
-    #bucketEmpty, #eventsEmpty { margin:12px 0 0; }
+    #bucketEmpty, #chartEmpty { margin:12px 0 0; }
     .section-header { display:flex; align-items:center; justify-content:space-between; gap:14px; flex-wrap:wrap; }
     .section-header h2 { margin:0; }
     .muted-small { color:var(--app-fg-muted); font-size:0.85rem; }
+    .chart-container { position:relative; width:100%; min-height:320px; }
+    #outputChart { width:100%; height:320px; display:block; }
+    .chart-legend { display:flex; flex-wrap:wrap; gap:16px; margin-top:12px; color:var(--app-fg-muted); font-size:0.9rem; }
+    .chart-legend span { display:inline-flex; align-items:center; gap:8px; }
+    .chart-legend .swatch { width:14px; height:14px; border-radius:4px; display:inline-block; }
+    .chart-legend .swatch.pass { background:#22c55e; }
+    .chart-legend .swatch.fail { background:#ef4444; }
     @media (max-width: 720px) {
       .filters { flex-direction:column; align-items:stretch; }
       .filters button { width:100%; }
       .table-scroll table { min-width:600px; }
+      .chart-container { min-height:260px; }
+      #outputChart { height:260px; }
     }
   </style>
 </head>
@@ -126,33 +135,21 @@
 
     <section class="card">
       <div class="section-header">
-        <h2>Weigh Events</h2>
-        <span id="eventsSummary" class="muted-small"></span>
+        <h2>Output Over Time</h2>
+        <span id="chartSummary" class="muted-small"></span>
       </div>
-      <div class="table-scroll">
-        <table>
-          <thead>
-            <tr>
-              <th scope="col">Timestamp</th>
-              <th scope="col">Variant</th>
-              <th scope="col">Serial</th>
-              <th scope="col">Moulding Serial</th>
-              <th scope="col">Contract</th>
-              <th scope="col">Order #</th>
-              <th scope="col">Operator</th>
-              <th scope="col">Colour</th>
-              <th scope="col">Result</th>
-              <th scope="col">Net (g)</th>
-            </tr>
-          </thead>
-          <tbody id="eventRows"></tbody>
-        </table>
+      <div class="chart-container">
+        <canvas id="outputChart" aria-label="Stacked bar chart of production output" role="img"></canvas>
       </div>
-      <p id="eventsEmpty" class="muted" hidden>No weigh events recorded for the selected filters.</p>
-      <p id="eventsNotice" class="muted-small"></p>
+      <p id="chartEmpty" class="muted" hidden>No production totals found for the selected filters.</p>
+      <div class="chart-legend">
+        <span><span class="swatch pass"></span>Pass</span>
+        <span><span class="swatch fail"></span>Fail</span>
+      </div>
+      <p class="muted-small">Bars show total output for each interval with pass counts in green and fail counts in red.</p>
     </section>
   </main>
 
-  <script src="/static/production.js?v=20241015"></script>
+  <script src="/static/production.js?v=20241018"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the Production Output weigh-event table with a stacked pass/fail bar chart, including legend and helper copy
- render the stacked chart on the client with responsive canvas drawing and resize handling
- move the home screen status message into the weigh card and double its font size for higher visibility

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68dd683a94908332873ecc7d6257ad5d